### PR TITLE
Output directory should not contain ending slash 

### DIFF
--- a/src/robot_api/configs/default_config.json
+++ b/src/robot_api/configs/default_config.json
@@ -264,7 +264,7 @@
                 "infile" : "aggregated/aggregated_protocol_hostnames.txt"
             },
             "description" : "Post enumeration tool for screen grabbing websites. All images will be downloaded to outfile: httpscreenshot.tar and unpacked httpscreenshots",
-            "output" : "/tmp/output/",
+            "output" : "/tmp/output",
             "infile" : "/tmp/output/aggregated/aggregated_protocol_hostnames.txt"
         },
         "Eyewitness": {
@@ -288,7 +288,7 @@
                 "infile" : "aggregated/aggregated_protocol_hostnames.txt"
             },
             "description" : "Post enumeration tool for screen grabbing websites. All images will be downloaded to outfile: Eyewitness.tar and unpacked in Eyewitness",
-            "output" : "/tmp/output/",
+            "output" : "/tmp/output",
             "infile" : "/tmp/output/aggregated/aggregated_protocol_hostnames.txt"
         },
         "Nmap" : {
@@ -300,7 +300,7 @@
             "default_conf" : "docker_buildfiles/Dockerfile.Nmap.Screenshot.tmp",
             "active_conf" : "docker_active/Dockerfile.Nmap.Screenshot",
             "description" : "Post enumeration tool for screen grabbing websites. (Chrome is not installed in the dockerfile due. Options are chromium-browser/firefox/wkhtmltoimage)",
-            "output" : "/tmp/output/",
+            "output" : "/tmp/output",
             "infile" : "/tmp/output/aggregated/aggregated_hostnames.txt",
             "tool" : "chromium-browser"
         },
@@ -313,7 +313,7 @@
             "default_conf" : "docker_buildfiles/Dockerfile.Gowitness.Screenshot.tmp",
             "active_conf" : "docker_active/Dockerfile.Gowitness.Screenshot",
             "description" : "gowitness is a website screenshot utility written in Golang",
-            "output" : "/tmp/output/",
+            "output" : "/tmp/output",
             "infile" : "/tmp/output/aggregated/aggregated_protocol_hostnames.txt"
         },
         "Webscreenshot" : {
@@ -337,7 +337,7 @@
                 "infile" : "aggregated/aggregated_protocol_hostnames.txt"
             },
             "description" : "Post enumeration tool for screen grabbing websites. (Chrome is not installed in the dockerfile due. Options are chromium-browser/firefox/wkhtmltoimage)",
-            "output" : "/tmp/output/",
+            "output" : "/tmp/output",
             "infile" : "/tmp/output/aggregated/aggregated_protocol_hostnames.txt",
             "tool" : "phantomjs"
         }


### PR DESCRIPTION
/tmp/output/ needs to be changed to /tmp/output in config.json this is to allow the appending of paths in Dockerfiles: $output/somedirectory.