### PR TITLE
Regex for hostnames

### DIFF
--- a/src/robot_api/api/aggregation.py
+++ b/src/robot_api/api/aggregation.py
@@ -116,7 +116,7 @@ class Aggregation:
                           'w') as _file:
                     _file.writelines(
                         "\n".join(
-                            list(f"https://{host[0]}\nhttp://{host[0]}"
+                            list(f"https://{host[0]}.{self.domain}\nhttp://{host[0]}.{self.domain}"
                                  for host in hostnames)))
 
             if dump_headers:
@@ -248,17 +248,19 @@ class Aggregation:
             r"(?:(?:1\d\d|2[0-5][0-5]|2[0-4]\d|0?[1-9]\d|0?0?\d)\.){3}(?:1\d\d|2[0-5][0-5]|2[0-4]\d|0?[1-9]\d|0?0?\d)")
         # hostname_reg = re.compile(r"([A-Za-z0-9\-]*\.?)*\." + self.domain)
         hostname_reg = re.compile(
-            r"([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*?\." + self.domain)
+            r"([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*?\." 
+            + self.domain
+            + r"(\:?[0-9]{1,6})?")
         results = []
         try:
             with open(filename, "r", encoding='utf-8') as _file:
                 for line in tqdm(_file.readlines(), desc=f"{filename} parsing..."):
-                    _host = hostname_reg.match(line)
+                    _host = hostname_reg.search(line)
                     if _host is not None:
-                        _host = _host.group(1)
-                    _ip = ip_reg.match(line)
+                        _host = _host.group(0)
+                    _ip = ip_reg.search(line)
                     if _ip is not None:
-                        _ip = _ip.group()
+                        _ip = _ip.group(0)
                     try:
                         if _host is not None and _ip is None:
                             _ip = socket.gethostbyname(_host)

--- a/src/robot_api/api/aggregation.py
+++ b/src/robot_api/api/aggregation.py
@@ -116,7 +116,7 @@ class Aggregation:
                           'w') as _file:
                     _file.writelines(
                         "\n".join(
-                            list(f"https://{host[0]}.{self.domain}\nhttp://{host[0]}.{self.domain}"
+                            list(f"https://{host[0]}\nhttp://{host[0]}"
                                  for host in hostnames)))
 
             if dump_headers:
@@ -250,7 +250,7 @@ class Aggregation:
         hostname_reg = re.compile(
             r"([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*?\." 
             + self.domain
-            + r"(\:?[0-9]{1,6})?")
+            + r"(\:?[0-9]{1,5})?")
         results = []
         try:
             with open(filename, "r", encoding='utf-8') as _file:

--- a/src/robot_api/docker_buildfiles/Dockerfile.Gowitness.Screenshot.tmp
+++ b/src/robot_api/docker_buildfiles/Dockerfile.Gowitness.Screenshot.tmp
@@ -29,4 +29,4 @@ ENV https_proxy $proxy
 ENV HOME /
 
 
-ENTRYPOINT mkdir $output/gowitness && cd $output/gowitness && gowitness file -s $infile --threads 20
+ENTRYPOINT mkdir -p $output/gowitness && cd $output/gowitness && gowitness file -s $infile --threads 20

--- a/src/robot_api/docker_buildfiles/Dockerfile.Nmap.Screenshot.tmp
+++ b/src/robot_api/docker_buildfiles/Dockerfile.Nmap.Screenshot.tmp
@@ -25,4 +25,4 @@ RUN if [ -n $dns ]; \
 
 WORKDIR $output
 
-ENTRYPOINT mkdir $output/nmapscreen && cd $output/nmapscreen && nmap --script http-screenshot --script-args tool=$tool -iL $infile -p "80,8080,443,8888"
+ENTRYPOINT mkdir -p $output/nmapscreen && cd $output/nmapscreen && nmap --script http-screenshot --script-args tool=$tool -iL $infile -p "80,8080,443,8888"

--- a/src/robot_api/robot.py
+++ b/src/robot_api/robot.py
@@ -485,7 +485,6 @@ class Robot:
                   "to possibility of user input")
             self._run_ansible(post_enum_ansible, infile)
 
-        print("[*] Inspection Done")
         if _threads:
             try:
                 [thread.join() for thread in _threads if thread]
@@ -493,6 +492,8 @@ class Robot:
                 self._print("Keyboard Interrupt sending kill signal to docker")
                 _ = [doc.kill() for doc in post_doc]
                 raise KeyboardInterrupt
+
+        print("[*] Inspection Done")
 
     def upload(self, **kwargs):
         """Uploads files under filepath to upload destination


### PR DESCRIPTION
Added regex to check for Port. 

Most tools will spit out only the subdomain. However, there is a use case where someone may have a list of subdomains with port numbers for web services which they would like to screenshot if possible. Adding this regex now allows someone to specify a file during rebuild such that the hostnames + port numbers can be added to the database and as such to the scanners that take screenshots